### PR TITLE
uploading an artifact

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -24,3 +24,10 @@ jobs:
         with:
           repositories: urls.txt
       - run: tree -a -I '.git' -L 5 ./
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: tortellini-results
+          path: |
+            .tortellini
+            !.tortellini/in


### PR DESCRIPTION
## Description

This PR adds uploading the contents of `.tortellini` (excluding `.tortellini/in`) to an artifact, such that users may look into the generated files.

Refs: #79 

- [x] I read and I followed [contributing guidelines](https://github.com/tortellini-tools/action/blob/main/CONTRIBUTING.md)
- [x] [☝ Create an issue](https://github.com/NLeSC/licenseguard/issues/new/choose) to discuss what you are going to do

## Checklist

This section should be filled in by the creator of this pull request to make sure the pull request is ready to review.

- [x] This pull request has a descriptive title
- [x] Code is written according to the code quality guidelines
- [x] Documentation if applicable is available
- [x] Tests run successfully
- [x] All checks below this pull request were successful

## Instructions to review the pull request

Running the tortellini workflow should result in an artifact being present after the workflow finishes, see e.g. https://github.com/tortellini-tools/action/actions/runs/903430405 